### PR TITLE
Changed from JRE to JDK because tools like jstack which are critical …

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2016-2017 ForgeRock AS.
 
-FROM openjdk:8u151-jre-alpine
+FROM openjdk:8u151-jdk-alpine
 
 ENV FORGEROCK_HOME /opt/forgerock
 
@@ -13,7 +13,7 @@ ENV FORGEROCK_HOME /opt/forgerock
 # bind-tools for dig (dns diagnostics)
 # iputils - ping command
 # CDIC-72 - find / -perm +6000 -type f -exec chmod a-s {} \; || true
-RUN apk add --no-cache su-exec unzip curl bash bind-tools iputils \
+RUN apk add --no-cache su-exec unzip curl bash bind-tools iputils sysstat \
     && apk del --no-cache bind \
     && mkdir -p "${FORGEROCK_HOME}" \
     && addgroup -g 11111 forgerock \


### PR DESCRIPTION
…for troubleshooting are missing from the JRE.  Also added sysstat so that we can monitor OS I/O if needed.